### PR TITLE
Add functions for moving columns to beginning/end of table

### DIFF
--- a/Modules/Table.MoveColumnsToBeginning.pq
+++ b/Modules/Table.MoveColumnsToBeginning.pq
@@ -1,0 +1,22 @@
+/**
+Moves a list of columns of a given table to the beginning of that table.
+
+Does the same thing as right-click column -> Move -> To Beginning in the GUI,
+except that it does not hardcode the rest of the column names into the query.
+
+
+Arguments:
+table
+    The table to transform
+column_names
+    A list of strings representing names of columns that are in the table
+
+**/
+
+
+(table as table, column_names as list) =>
+    let
+        NewColumns = column_names & List.RemoveItems(Table.ColumnNames(table), column_names),
+        NewTable = Table.ReorderColumns(table, NewColumns)
+    in
+        NewTable

--- a/Modules/Table.MoveColumnsToEnd.pq
+++ b/Modules/Table.MoveColumnsToEnd.pq
@@ -1,0 +1,22 @@
+/**
+Moves a list of columns of a given table to the end of that table.
+
+Does the same thing as right-click column -> Move -> To End in the GUI,
+except that it does not hardcode the rest of the column names into the query.
+
+
+Arguments:
+table
+    The table to transform
+column_names
+    A list of strings representing names of columns that are in the table
+
+**/
+
+
+(table as table, column_names as list) =>
+    let
+        NewColumns = List.RemoveItems(Table.ColumnNames(table), column_names) & column_names,
+        NewTable = Table.ReorderColumns(table, NewColumns)
+    in
+        NewTable

--- a/Tests/Tests.MoveColumnsToBeginning.pq
+++ b/Tests/Tests.MoveColumnsToBeginning.pq
@@ -1,0 +1,27 @@
+/**
+Unit tests for Table.MoveColumnsToBeginning
+**/
+
+[
+    Table.MoveColumnsToBeginning = LibPQ("Table.MoveColumnsToBeginning"),
+
+    headers_before = {"foo", "bar", "baz", "bax"},
+    data_before = {{1, 2}, {3, 4}, {5, 6}, {7, 8}},
+    table_before = Table.FromColumns(data_before, headers_before),
+
+    headers_after = {"bar", "baz", "foo", "bax"},
+    data_after = {{3, 4}, {5, 6}, {1, 2}, {7, 8}},
+    table_after = Table.FromColumns(data_after, headers_after),
+
+    shifted_columns = Table.MoveColumnsToBeginning(table_before, {"bar", "baz"}),
+
+    testCanMoveColumnsBefore =
+        Assert[Equal](shifted_columns, table_after),
+
+    // table equality test ignores order of columns so we need to check explicitly
+    testColumnsInCorrectOrder =
+        Assert[Equal](Table.ColumnNames(shifted_columns), headers_after),
+
+    /** Import assertion functions **/
+    Assert = LibPQ("UnitTest.Assert")
+] meta [LibPQ.TestSuite = 1]

--- a/Tests/Tests.MoveColumnsToEnd.pq
+++ b/Tests/Tests.MoveColumnsToEnd.pq
@@ -1,0 +1,27 @@
+/**
+Unit tests for Table.MoveColumnsToEnd
+**/
+
+[
+    Table.MoveColumnsToEnd = LibPQ("Table.MoveColumnsToEnd"),
+
+    headers_before = {"foo", "bar", "baz", "bax"},
+    data_before = {{1, 2}, {3, 4}, {5, 6}, {7, 8}},
+    table_before = Table.FromColumns(data_before, headers_before),
+
+    headers_after = {"foo", "bax", "bar", "baz"},
+    data_after = {{1, 2}, {7, 8}, {3, 4}, {5, 6}},
+    table_after = Table.FromColumns(data_after, headers_after),
+
+    shifted_columns = Table.MoveColumnsToEnd(table_before, {"bar", "baz"}),
+
+    testCanMoveColumnsEnd =
+        Assert[Equal](shifted_columns, table_after),
+
+    // table equality test ignores order of columns so we need to check explicitly
+    testColumnsInCorrectOrder =
+        Assert[Equal](Table.ColumnNames(shifted_columns), headers_after),
+
+    /** Import assertion functions **/
+    Assert = LibPQ("UnitTest.Assert")
+] meta [LibPQ.TestSuite = 1]


### PR DESCRIPTION
These are two fairly simple functions I use a lot. The GUI can do these things, but the generated code is unwieldy because it hardcodes all of the columns in the query, rather than just the ones that are being moved. So if you amend previous steps so that the table has different columns, the code generated by the GUI will break.

Wasn't really sure if they are welcome in this project but it only took me 10 minutes to write tests for, so I thought why not.